### PR TITLE
Minor fixes

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -534,11 +534,11 @@ The target hart jumps to higher privilege mode(S or VS mode) by executing at
 
 [cols="<,>",options="header,compact"]
 |===
-|Register Name		|Value  |
-|satp			|  0    |
-|sstatus.sie		|  0    |
-|a0			|hartid |
-|a1			|priv   |
+|Register Name		|Value
+|satp			|  0
+|sstatus.sie		|  0
+|a0			|hartid
+|a1			|priv
 |===
 
 All other registers remain in an undefined state.

--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -126,7 +126,7 @@ struct sbiret sbi_get_spec_version(void);
 ----
 Returns the current SBI specification version.  This function must always
 succeed.  The minor number of the SBI specification is encoded in the low 24
-bits, with the major number encoded in the next 7 bits.  Bit 32 must be 0 and
+bits, with the major number encoded in the next 7 bits.  Bit 31 must be 0 and
 is reserved for future expansion.
 
 [source, C]


### PR DESCRIPTION
This PR contains two minor fixes.

1. “Bit 32” here (1-origin) seems to be a bit off (a slight deviation from the RISC-V ISA Manual) and “Bit 31” (0-origin) is probably better.
2. A table in Hart State Management Extension contains a format error.