### PR TITLE
Fix list rendering in RFENCE Extension

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -336,6 +336,7 @@ addresses (i.e. start_addr and size), have to abide by the below constraints
 on range parameters.
 
 The remote fence function acts as a full tlb flush if
+
 	* `start_addr` and `size` are both 0
 	* `size` is equal to 2^XLEN-1
 


### PR DESCRIPTION
Without an empty line, the two items are not rendered as a list but put inline with the previous line.