### PR TITLE
Added sbi_get_misa()

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -153,6 +153,7 @@ non-zero value if it is available.
 
 [source, C]
 ----
+struct sbiret sbi_get_misa(void);
 struct sbiret sbi_get_mvendorid(void);
 struct sbiret sbi_get_marchid(void);
 struct sbiret sbi_get_mimpid(void);
@@ -172,6 +173,7 @@ value for any of these CSRs.
 | sbi_get_mvendorid             |           4 |         0x10
 | sbi_get_marchid               |           5 |         0x10
 | sbi_get_mimpid                |           6 |         0x10
+| sbi_get_misa                  |           7 |         0x10
 |===
 
 === SBI Implementation IDs

--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -223,7 +223,8 @@ rounded up to the next integer.
 void sbi_clear_ipi(void)
 ----
 Clears the pending IPIs if any. The IPI is cleared only in the hart for which
-this SBI call is invoked.
+this SBI call is invoked.  (`sbi_clear_ipi` is deprecated; S-mode code can
+clear `sip.SSIP` directly).
 
 [source, C]
 ----


### PR DESCRIPTION
See issue #40.

To restate, the Privileged ISA Spec says it all:
> We require that lower privilege levels execute environment calls instead of reading CPU
> registers to determine features available at each privilege level. This enables virtualization layers
> to alter the ISA observed at any level, and supports a much richer command interface without
> burdening hardware designs.