### PR TITLE
Sbi clear ipi deprecated

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -153,6 +153,7 @@ non-zero value if it is available.
 
 [source, C]
 ----
+struct sbiret sbi_get_misa(void);
 struct sbiret sbi_get_mvendorid(void);
 struct sbiret sbi_get_marchid(void);
 struct sbiret sbi_get_mimpid(void);
@@ -172,6 +173,7 @@ value for any of these CSRs.
 | sbi_get_mvendorid             |           4 |         0x10
 | sbi_get_marchid               |           5 |         0x10
 | sbi_get_mimpid                |           6 |         0x10
+| sbi_get_misa                  |           7 |         0x10
 |===
 
 === SBI Implementation IDs

--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -223,7 +223,8 @@ rounded up to the next integer.
 void sbi_clear_ipi(void)
 ----
 Clears the pending IPIs if any. The IPI is cleared only in the hart for which
-this SBI call is invoked.
+this SBI call is invoked.  (`sbi_clear_ipi` is deprecated; S-mode code can
+clear `sip.SSIP` directly).
 
 [source, C]
 ----


### PR DESCRIPTION
See issue #47.  Note that only the second commit https://github.com/riscv/riscv-sbi-doc/commit/e8a27d65418ad4b2bc7935240a579bc3eca4166a is relevant.