### PR TITLE
Add SBI implementation ID for Diosix

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -183,6 +183,7 @@ value for any of these CSRs.
 | 1                 | OpenSBI
 | 2                 | Xvisor
 | 3                 | KVM
+| 4                 | Diosix
 |===
 
 == Legacy SBI Extension, Extension IDs 0x00 through 0x0F


### PR DESCRIPTION
Diosix is a bare-metal open-source hypervisor written in Rust for RISC-V systems that implements the RISC-V SBI to communicate with supervisor kernels. As such, it needs an implementation ID, which I request here. Diosix's source code and documentation can be found here: https://github.com/diodesign/diosix