### PR TITLE
Define configuration of the mseccfg CSR

### DIFF
--- a/riscv-sbi.adoc
+++ b/riscv-sbi.adoc
@@ -71,6 +71,8 @@ include::src/terms.adoc[]
 
 include::src/binary-encoding.adoc[]
 
+include::src/configuration.adoc[]
+
 include::src/ext-base.adoc[]
 
 include::src/ext-legacy.adoc[]

--- a/src/configuration.adoc
+++ b/src/configuration.adoc
@@ -1,0 +1,7 @@
+== Configuration
+
+=== Machine Security Configuration Register (mseccfg)
+
+M-mode SBI implementations shall set mseccfg.sseed=1 and mseccfg.useed=0 if
+extension Zkr <<crypt_ext_1_v1.0.1>> is available. This allows S-mode but not
+U-mode to access the seed CSR.

--- a/src/references.adoc
+++ b/src/references.adoc
@@ -3,3 +3,6 @@
 * [[[priv_v1.12]]] The RISC-V Instruction Set Manual, Volume II:
 Privileged Architecture, Document Version 20211203,
 URL: https://github.com/riscv/riscv-isa-manual/releases/tag/Priv-v1.12
+* [[[crypt_ext_1_v1.0.1]]] Cryptography Extensions, Volume I:
+Scalar & Entropy Source Instructions, Document Version v1.0.1
+URL: https://drive.google.com/file/d/1Thd010Eh2DqnhDHpDd3SM7Ame7KENkPw/view


### PR DESCRIPTION
Define that M-mode SBI implementations shall set

  mseccfg.sseed = 1
  mseccfg.useed = 0

if ISA extension Zkr is available.

This allows S- and HS-mode software to implement a random number generator.