### PR TITLE
Add CONTROL_TRANSFER_RECORDS bit to the SBI FWFT extension

### DIFF
--- a/src/ext-firmware-features.adoc
+++ b/src/ext-firmware-features.adoc
@@ -21,7 +21,9 @@ the features which supervisor-mode software may request to set or get.
                                             bits.
 | 0x00000005   | POINTER_MASKING_PMLEN    | Control the pointer masking
                                             length for supervisor-mode.
-| 0x00000006 -
+| 0x00000006   | CONTROL_TRANSFER_RECORDS | Control the Ssctr extension support
+                                            for supervisor-mode.
+| 0x00000007 -
   0x3fffffff   |                          | Local feature types reserved for
                                             future use.
 | 0x40000000 -
@@ -99,6 +101,12 @@ description. Upon system reset, global and local feature values are reset.
 ! 0 ! Disable pointer masking for supervisor-mode.
 ! N ! Enable pointer masking for supervisor-mode with PMLEN >= N.
       A call to `sbi_fwft_get()` returns the actual value of PMLEN.
+!===
+| CONTROL_TRANSFER_RECORDS                          | 0     | Local |
+[cols="1,4"]
+!===
+! 0 ! Disable Control transfer records extension for supervisor-mode.
+! 1 ! Enable Control transfer records extension for supervisor-mode.
 !===
 |===
 


### PR DESCRIPTION
Allow supervisor software to request that Ssctr be enabled for S-mode. An SBI implementation can decide to keep Ssctr always enabled and return SBI_ERR_DENIED on sbi_fwft_set() call.

I have done a PoC for this. Here is a link to the guide to setup and run CTR demo on KVM guest and host.
 https://github.com/rajnesh-kanwal/linux/wiki/Running-CTR-basic-demo-on-KVM-QEMU-RISCV-Virt-machine

Links to PoC branches:
https://github.com/rajnesh-kanwal/linux/commits/b4/ctr_upstream_kvm_v1/
https://github.com/rajnesh-kanwal/opensbi/commits/b4/ctr_upstream_kvm_v1/
https://github.com/rajnesh-kanwal/kvmtool/commits/b4/ctr_upstream_kvm_v1

QEMU remains same and there are no changes other than original CTR patches. 
https://github.com/rajnesh-kanwal/qemu/commits/b4/ctr_upstream_v5/

Note: kvmtool changes are not for upstreaming but these are for testing only.

+ @atishp04 @avpatel  