### PR TITLE
ext-debug-triggers: Fix SBI_ERR_BAD_RANGE inequality test

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     # Step 1: Checkout the repository
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         submodules: 'recursive'
 
@@ -52,7 +52,7 @@ jobs:
 
     # Step 4: Upload the built PDF files as a single artifact
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Build Artifacts
         path: ${{ github.workspace }}/*.pdf
@@ -60,7 +60,7 @@ jobs:
       
     # Create Release
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: ${{ github.workspace }}/*.pdf
         tag_name: v${{ github.event.inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 DOCKER_RUN := docker run --rm -v ${PWD}:/build -w /build \
-riscvintl/riscv-docs-base-container-image:latest
+ghcr.io/riscv/riscv-docs-base-container-image:latest
 
 DEPS = src/contributors.adoc
 DEPS += src/changelog.adoc

--- a/src/ext-debug-triggers.adoc
+++ b/src/ext-debug-triggers.adoc
@@ -159,7 +159,7 @@ The possible error codes returned in `sbiret.error` are shown in
 | SBI_SUCCESS       | State and configuration of triggers read successfully.
 | SBI_ERR_NO_SHMEM  | Shared memory for debug triggers is disabled.
 | SBI_ERR_BAD_RANGE | Either `trig_idx_base >= trig_max` or
-                      `trig_idx_base + trig_count >= trig_max`
+                      `trig_idx_base + trig_count > trig_max`
 |===
 
 === Function: Install triggers (FID #3)
@@ -222,7 +222,7 @@ The possible error codes returned in `sbiret.error` are shown in
 | Error code            | Description
 | SBI_SUCCESS           | Triggers installed successfully.
 | SBI_ERR_NO_SHMEM      | Shared memory for debug triggers is disabled.
-| SBI_ERR_BAD_RANGE     | `trig_count >= trig_max`
+| SBI_ERR_BAD_RANGE     | `trig_count > trig_max`
 | SBI_ERR_INVALID_PARAM | One of the trigger configuration words `trig_tdata1`, `trig_tdata2`,
                           or `trig_tdata3` has an invalid value.
 | SBI_ERR_FAILED        | Failed to assign `trig_idx` or HW debug trigger for one of the
@@ -282,7 +282,7 @@ The possible error codes returned in `sbiret.error` are shown in
 | Error code            | Description
 | SBI_SUCCESS           | Triggers updated successfully.
 | SBI_ERR_NO_SHMEM      | Shared memory for debug triggers is disabled.
-| SBI_ERR_BAD_RANGE     | `trig_count >= trig_max`
+| SBI_ERR_BAD_RANGE     | `trig_count > trig_max`
 | SBI_ERR_INVALID_PARAM | One of the trigger configuration in the shared memory has an
                           invalid of `trig_idx` (i.e. `trig_idx >= trig_max`), `trig_tdata1`,
                           `trig_tdata2`, or `trig_tdata3`.


### PR DESCRIPTION
The bad range condition for trigger counts should be > trig_max rather than >= trig_max. Fix these in tables 100, 101, 102.

Link: https://github.com/riscv-non-isa/riscv-sbi-doc/issues/257