### PR TITLE
doc: clarify 4-byte alignment requirement for start_addr

### DIFF
--- a/src/ext-hsm.adoc
+++ b/src/ext-hsm.adoc
@@ -137,6 +137,8 @@ The possible error codes returned in `sbiret.error` are shown in the
                               * Executable access to the address is prohibited
                                 by a physical memory protection mechanism or
                                 H-extension G-stage for supervisor-mode.
+                              * It is not 4-byte-aligned, as required by the
+                                stvec BASE address alignment requirement.
 | SBI_ERR_INVALID_PARAM     | `hartid` is not a valid hartid as the
                               corresponding hart cannot be started in supervisor
                               mode.
@@ -290,6 +292,8 @@ The possible error codes returned in `sbiret.error` are shown in the
                             * Executable access to the address is prohibited
                               by a physical memory protection mechanism or
                               H-extension G-stage for supervisor-mode.
+                            * It is not 4-byte-aligned, as required by the
+                              stvec BASE address alignment requirement.
 | SBI_ERR_FAILED          | The suspend request failed for unspecified or
                             unknown other reasons.
 |===

--- a/src/ext-sys-suspend.adoc
+++ b/src/ext-sys-suspend.adoc
@@ -101,6 +101,8 @@ The possible error codes returned in `sbiret.error` are shown in
                             * Executable access to the address is prohibited by
                               a physical memory protection mechanism or
                               H-extension G-stage for supervisor mode.
+                            * It is not 4-byte-aligned, as required by the
+                              stvec BASE address alignment requirement.
 | SBI_ERR_DENIED          | The suspend request failed due to unsatisfied entry
                             criteria.
 | SBI_ERR_FAILED          | The suspend request failed for unspecified or


### PR DESCRIPTION
Linux can pass a non-4-byte-aligned address to sbi_hsm_start() [1]. To prevent this invalid usage, we now explicitly document that `start_addr` must be 4-byte-aligned (matching the stvec/vstvec BASE requirement).

[1]: https://lore.kernel.org/linux-riscv/20260413132009.133752-1-cp0613@linux.alibaba.com/